### PR TITLE
Add sales order tracker with smart mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ A simple Streamlit app template for you to modify!
    ```
    $ streamlit run streamlit_app.py
    ```
+
+### Using the sales order tracker
+
+Upload a CSV file with your sales orders or use the bundled `sample_sales_orders.csv`.
+The app automatically maps common column names, generates `item_id` values and
+marks late orders. Edit the table directly in your browser and click **Save
+orders** to write updates to `saved_orders.csv`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 streamlit
+pandas
+st-aggrid
+python-dateutil

--- a/sample_sales_orders.csv
+++ b/sample_sales_orders.csv
@@ -1,0 +1,4 @@
+Sales Order,Item,Customer Name,Est. Ship Date,Orig. Ship Date,Order Status,Quantity
+1212083971,40,AAON INC.,2025-05-25,2025-05-20,Open,5
+1212083972,10,ABB LTD.,2025-05-18,2025-05-17,Open,3
+1212083973,20,XYZ CORP,2025-05-10,2025-05-05,Closed,2

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,77 @@
+import os
+from datetime import datetime
 import streamlit as st
+import pandas as pd
+from st_aggrid import AgGrid, GridOptionsBuilder
 
-st.title("🎈 My new app")
-st.write(
-    "Let's start building! For help and inspiration, head over to [docs.streamlit.io](https://docs.streamlit.io/)."
+st.set_page_config(page_title="Sales Orders Tracker", page_icon="📦")
+
+# ABB-themed colors
+ABB_RED = "#E60012"
+
+st.markdown(
+    f"""
+    <style>
+    .stButton>button {{ background-color:{ABB_RED}; color:white; }}
+    </style>
+    """,
+    unsafe_allow_html=True,
 )
+
+st.title("📦 Sales Orders Tracker")
+
+# Load CSV either from upload or bundled sample
+uploaded = st.file_uploader("Upload sales order CSV", type="csv")
+if uploaded is not None:
+    df = pd.read_csv(uploaded)
+else:
+    df = pd.read_csv("sample_sales_orders.csv")
+
+# Column mapping rules
+COLUMN_MAP = {
+    "Cust. Material": "Material",
+    "First Date": "Requested Date",
+    "Est. Ship Date": "Expected Delivery",
+    "Orig. Ship Date": "Original Delivery",
+    "Sales Order": "sales_order",
+    "Item": "item",
+    "Customer Name": "customer",
+}
+
+# Apply mapping
+renamed = {}
+for col in df.columns:
+    key = col.strip()
+    renamed[col] = COLUMN_MAP.get(key, key)
+
+df.rename(columns=renamed, inplace=True)
+
+# Auto-generate item_id
+if {"sales_order", "item"}.issubset(df.columns):
+    df["item_id"] = df["sales_order"].astype(str) + "-" + df["item"].astype(str)
+
+# Flag late orders
+if "Expected Delivery" in df.columns:
+    today = pd.Timestamp.utcnow().normalize()
+    df["Late"] = pd.to_datetime(df["Expected Delivery"], errors="coerce") < today
+
+st.subheader("Orders")
+
+# Compare with previously saved orders if available
+previous_path = "saved_orders.csv"
+if os.path.exists(previous_path):
+    prev_df = pd.read_csv(previous_path)
+    changed = df.merge(prev_df, indicator=True, how="outer")
+    changed = changed[changed["_merge"] != "both"]
+    if not changed.empty:
+        st.expander("Changes since last save").dataframe(changed)
+
+# Editable grid
+gb = GridOptionsBuilder.from_dataframe(df)
+gb.configure_default_column(editable=True)
+grid_response = AgGrid(df, gridOptions=gb.build(), update_mode="MODEL_CHANGED", editable=True, fit_columns_on_grid_load=True)
+updated_df = pd.DataFrame(grid_response["data"])
+
+if st.button("Save orders"):
+    updated_df.to_csv(previous_path, index=False)
+    st.success("Orders saved to saved_orders.csv")


### PR DESCRIPTION
## Summary
- add pandas-based sales order tracker with ABB-themed design
- map column names automatically and highlight late orders
- show differences from previously saved orders
- bundle a sample CSV for testing

## Testing
- `python -m py_compile streamlit_app.py`
